### PR TITLE
Server side cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+api/cache

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ You'll want to change the `TSNCOR_DEPLOYMENT_WEB_APP_URL` variable.
 
 ## Code structure
 
-This is a relatively plain "hand-crafted" website with some HTML and CSS.
+This is a relatively plain "hand-crafted" website with some HTML and CSS, and a little PHP.
 You'll find the main structure in `index.html`, and the biggest part of the logic in `modules/store.js`.
 
 There's a very small bit of logic which runs server-side.
 This you'll find in the `api` directory.
 This part is responsible for caching the spreadsheet data, which is necessary since getting the data from the spreadsheet is quite slow.
+It also caches the award ribbon pictures. This is needed for the images to work. Google made a change in early 2024 that made it no longer possible to get the award images directly.
 
 ### Client
 
@@ -47,7 +48,15 @@ There are some more cool features. The important ones are:
 
 There are a few PHP files in `api`. These are responsible for server side caching.
 
-TODO: document how it works.
+The data we display comes from two different sources: The Apps Script (this is attached to the COR spreadsheet and gives us the spreadsheet data) and the Google Drive (This is where the pictures for award ribbons are).
+
+It takes quite long to retrieve data from Google, so we have a cache: we first load the data from Google onto the TSN server, and then from the TSN server to the client.
+
+The `api/cache_function.php` file contains the main logic for fetching a cached file, making sure it isn't expired, and sending it to the client. This function is used by all other PHP scripts.
+
+In `api/appsscript.php` we accept an appsscript query and return the (cached) result from appsscript.
+
+In `api/images.php` we accept a query for an image file, and get the file from Google Drive.
 
 ### Look & Feel
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Work on this codebase is continued in https://github.com/tsnrp/tsncor-website --
 
 ## Configuration
 
-Some basic configuration can be done in `configuration.js`, where we just define a few variables that determine the behaviour of the app. 
-If you're here because the COR spreadsheet told you to "update the AppsScript deployment URL in the website", then this is the file you need to look at.
+Some basic configuration can be done in `configuration.js` as well as `api/configuration.php`, where we just define a few variables that determine the behaviour of the app. 
+If you're here because the COR spreadsheet told you to "update the AppsScript deployment URL in the website", then you'll want to check out `api/configuration.php`.
 You'll want to change the `TSNCOR_DEPLOYMENT_WEB_APP_URL` variable.
 
 
@@ -18,7 +18,11 @@ You'll want to change the `TSNCOR_DEPLOYMENT_WEB_APP_URL` variable.
 This is a relatively plain "hand-crafted" website with some HTML and CSS.
 You'll find the main structure in `index.html`, and the biggest part of the logic in `modules/store.js`.
 
-### Logic
+There's a very small bit of logic which runs server-side.
+This you'll find in the `api` directory.
+This part is responsible for caching the spreadsheet data, which is necessary since getting the data from the spreadsheet is quite slow.
+
+### Client
 
 The code uses petite-vue (based on vue.js) to introduce some reactive patterns.
 If this is something you've never heard of, here's the TLDR:
@@ -38,6 +42,12 @@ There are some more cool features. The important ones are:
 * the `v-if` directive can be added to an HTML tag to make this tag only visible if a javascript condition is true
 * the `v-for` directive can be added to an HTML tag. This will make petite-vue repeat the tag once for each item in a javascript list.
 * the `v-bind` directive can be added to inputs (like the search field). This means: "whenever this input field changes, update that javascript variable, and vice versa".
+
+### API (caching)
+
+There are a few PHP files in `api`. These are responsible for server side caching.
+
+TODO: document how it works.
 
 ### Look & Feel
 

--- a/api/appsscript.php
+++ b/api/appsscript.php
@@ -1,0 +1,21 @@
+<?php
+// This code fetches data from the Google Sheet via Apps Script, and stores it locally on the webserver.
+// It acts as a cache layer between the Google Sheet and the website, making the loading of data
+// much faster.
+
+include("configuration.php");
+include("cache_function.php");
+
+
+$query_key = htmlentities($_GET["key"]);
+$query_val = htmlentities($_GET["val"]);
+$cache_seconds = intval(htmlentities($_GET["max_age"] ?? $DEFAULT_CACHE_TIME_SECONDS));
+
+$appsscript_url = "{$TSNCOR_DEPLOYMENT_WEB_APP_URL}?{$query_key}={$query_val}";
+$file_path = "{$query_key}_{$query_val}.json"; // Path of file on local server, relative to current directory
+
+fetch_with_cache($appsscript_url, $file_path, $cache_seconds);
+
+// This ends the currently running process, so we don't keep hogging server resources.
+die();
+?>

--- a/api/appsscript.php
+++ b/api/appsscript.php
@@ -18,4 +18,3 @@ fetch_with_cache($appsscript_url, $file_path, $cache_seconds);
 
 // This ends the currently running process, so we don't keep hogging server resources.
 die();
-?>

--- a/api/cache_function.php
+++ b/api/cache_function.php
@@ -1,0 +1,57 @@
+<?php
+// This code fetches some sort of remote endpoint and stores it locally on the webserver.
+// It acts as a cache layer between the remote endpoint, making the loading
+// much faster.
+
+function fetch_with_cache($remote_url, $local_file, $cache_time_seconds) {
+    set_time_limit(180); // If this code takes longer than 3 minutes it will be cancelled.
+
+    // Now begins the actual part of getting the file.
+    $file_path = "cache/{$local_file}";
+    $cache_url = dirname($_SERVER['REQUEST_URI']) . '/' . $file_path; // Full path of the file on the local server
+    $refresh_cache = true;
+
+    // Ensure the cache directory exists
+    if (!is_dir("cache")) {
+        mkdir("cache", 0755);
+    }
+
+    if (file_exists($file_path)) {
+        // We have this file! Let's check if it is still fresh:
+        $mod_time = filemtime($file_path);
+        if (time() - $mod_time < $cache_time_seconds) {
+            $refresh_cache = false;
+        }
+    }
+
+    if ($refresh_cache) {
+        // We have determined earlier that we need to update the cached file, so let's do that now.
+        if (!function_exists('curl_init')){
+            // If we don't have curl, we can't fetch the files for caching, so we give up.
+            error_log("Warning: curl is not available.");
+            // We tell the client to find the file at its original location.
+            header("Location: {$remote_url}");
+            die();
+        }
+        $out_file = fopen($file_path, 'w');
+
+        $curl = curl_init($remote_url);
+        curl_setopt($curl, CURLOPT_FOLLOWLOCATION, true); // follow redirects
+        curl_setopt($curl, CURLOPT_FILE, $out_file); // save to the correct file path
+        $res = curl_exec($curl); // actually execute the command
+
+        // The result value indicates whether the curl was successful. If it wasn't, let's log the error.
+        if (!$res) {
+            error_log("Curl failed");
+            error_log(curl_error($curl));
+            header("Location: {$remote_url}");
+            curl_close($curl);
+            die();
+        }
+        curl_close($curl);
+    }
+
+    // Finally, tell the client where to find the cached file.
+    header("Location: {$cache_url}");
+}
+?>

--- a/api/cache_function.php
+++ b/api/cache_function.php
@@ -46,9 +46,21 @@ function fetch_with_cache($remote_url, $local_file, $cache_time_seconds) {
             error_log(curl_error($curl));
             header("Location: {$remote_url}");
             curl_close($curl);
+            fclose($out_file);
+            die();
+        }
+
+        if (curl_getinfo($curl, CURLINFO_RESPONSE_CODE) != 200) {
+            // In this case the request did go through but the response indicates some sort of error.
+            header("Location: {$remote_url}");
+            curl_close($curl);
+            fclose($out_file);
+            // This also means the file we just saved is probably useless, so let's delete it.
+            unlink($file_path);
             die();
         }
         curl_close($curl);
+        fclose($out_file);
     }
 
     // Finally, tell the client where to find the cached file.

--- a/api/cache_function.php
+++ b/api/cache_function.php
@@ -3,7 +3,7 @@
 // It acts as a cache layer between the remote endpoint, making the loading
 // much faster.
 
-function fetch_with_cache($remote_url, $local_file, $cache_time_seconds) {
+function fetch_with_cache($remote_url, $local_file, $cache_time_seconds, $send_response=true) {
     set_time_limit(180); // If this code takes longer than 3 minutes it will be cancelled.
 
     // Now begins the actual part of getting the file.
@@ -29,9 +29,12 @@ function fetch_with_cache($remote_url, $local_file, $cache_time_seconds) {
         if (!function_exists('curl_init')){
             // If we don't have curl, we can't fetch the files for caching, so we give up.
             error_log("Warning: curl is not available.");
-            // We tell the client to find the file at its original location.
-            header("Location: {$remote_url}");
-            die();
+            if ($send_response){
+                // We tell the client to find the file at its original location.
+                header("Location: {$remote_url}");
+                die();
+            }
+            return false;
         }
         $out_file = fopen($file_path, 'w');
 
@@ -44,26 +47,37 @@ function fetch_with_cache($remote_url, $local_file, $cache_time_seconds) {
         if (!$res) {
             error_log("Curl failed");
             error_log(curl_error($curl));
-            header("Location: {$remote_url}");
             curl_close($curl);
             fclose($out_file);
-            die();
+            if ($send_response){
+                // Since the curl wasn't successful, we let the client know where to find the original file.
+                header("Location: {$remote_url}");
+                die();
+            }
+            return false;
         }
 
         if (curl_getinfo($curl, CURLINFO_RESPONSE_CODE) != 200) {
             // In this case the request did go through but the response indicates some sort of error.
-            header("Location: {$remote_url}");
             curl_close($curl);
             fclose($out_file);
             // This also means the file we just saved is probably useless, so let's delete it.
             unlink($file_path);
-            die();
+            if ($send_response){
+                // Since the curl wasn't successful, we let the client know where to find the original file.
+                header("Location: {$remote_url}");
+                die();
+            }
+            return false;
         }
         curl_close($curl);
         fclose($out_file);
     }
 
-    // Finally, tell the client where to find the cached file.
-    header("Location: {$cache_url}");
+    // We only get this far if the caching was successful. So now we're sure we have the file.
+    if ($send_response){
+        // Finally, tell the client where to find the cached file.
+        header("Location: {$cache_url}");
+    }
+    return true;
 }
-?>

--- a/api/configuration.php
+++ b/api/configuration.php
@@ -1,0 +1,8 @@
+<?php
+
+// Time, in seconds, for which award images should be cached on the server
+$DEFAULT_CACHE_TIME_SECONDS = 60 * 60 * 24 * 7 * 2; // 2 weeks
+
+$TSNCOR_DEPLOYMENT_WEB_APP_URL = "https://script.google.com/macros/s/AKfycbyeDkrUHyaVfTBjYge400j-Hz6lxNw5sBlOKhjfTS1lzdeVkQqjL7ZeZROtWyaMmqk/exec";
+
+?>

--- a/api/configuration.php
+++ b/api/configuration.php
@@ -3,6 +3,11 @@
 // Time, in seconds, for which award images should be cached on the server
 $DEFAULT_CACHE_TIME_SECONDS = 60 * 60 * 24 * 7 * 2; // 2 weeks
 
-$TSNCOR_DEPLOYMENT_WEB_APP_URL = "https://script.google.com/macros/s/AKfycbyeDkrUHyaVfTBjYge400j-Hz6lxNw5sBlOKhjfTS1lzdeVkQqjL7ZeZROtWyaMmqk/exec";
+$TSNCOR_DEPLOYMENT_WEB_APP_URL = "https://script.google.com/macros/s/AKfycbzspyIb_DzhrM8mQPPKrFmnd-BJ3EFMNPzBH6ZoMOAUcXbOWn9WL_88yyl2VISX0J4cHg/exec";
 
-?>
+// URL of the API endpoint that gives the image data. This is part of the apps script.
+$TSNCOR_IMAGES_URL = $TSNCOR_DEPLOYMENT_WEB_APP_URL . "?images";
+// Filename we use to store the image data on the server
+$TSNCOR_IMAGES_CACHE_FILE = "images.json";
+// For how long should we store the image data on the server? (By default it's the same duration as the default cache duration)
+$TSNCOR_IMAGES_CACHE_MAX_AGE_SECONDS = $DEFAULT_CACHE_TIME_SECONDS;

--- a/api/images.php
+++ b/api/images.php
@@ -1,0 +1,17 @@
+<?php
+// This code fetches award images from Google Drive and stores them locally on disk.
+// It acts as a cache layer between the Google Drive and the website, making the loading of images
+// much faster.
+
+include("configuration.php");
+include("cache_function.php");
+
+$file_key = htmlentities($_GET["key"]); // This will be a Google Drive file ID
+$drive_url = "https://drive.google.com/uc?export=view&id={$file_key}"; // URL of file on google drive
+$cache_seconds = intval(htmlentities($_GET["max_age"] ?? $DEFAULT_CACHE_TIME_SECONDS));
+
+fetch_with_cache($drive_url, $file_key, $cache_seconds);
+
+// This ends the currently running process, so we don't keep hogging server resources.
+die();
+?>

--- a/api/images.php
+++ b/api/images.php
@@ -6,7 +6,35 @@
 include("configuration.php");
 include("cache_function.php");
 
-$file_key = htmlentities($_GET["key"]); // This will be a Google Drive file ID
+$images_cached = fetch_with_cache($TSNCOR_IMAGES_URL, $TSNCOR_IMAGES_CACHE_FILE, $TSNCOR_IMAGES_CACHE_MAX_AGE_SECONDS, false);
+
+if (!$images_cached) {
+    // We tried to get the image information into the cache, but it failed. Now we're screwed.
+    // We basically throw an error at the client and give up
+    header('HTTP/1.0 500 Internal Server Error');
+    header('X-ERROR-MESSAGE: Unable to retrieve requested image file.');
+    die();
+}
+
+$cache_file = "cache/{$TSNCOR_IMAGES_CACHE_FILE}";
+$file_content = file_get_contents($cache_file);
+$image_json = json_decode($file_content, true);
+
+$file_path = $_GET["key"]; // This will be the file path of a ribbon image
+
+// Okay this line has a lot going on. The problem is that `$file_path` might have different capitalization from what's in the `$image_json`.
+// To fix that, we find all entries in `$image_json` that are the same as the `$file_path` if lowercased, and then grab the first one.
+// That'll be the same entry, but with correct casing.
+$corrected_path = current(array_filter(array_keys($image_json), function($element) use ($file_path) { return strcmp(strtolower($element), strtolower($file_path)) == 0; }));
+
+$file_key = $image_json[$corrected_path]; // This will be the corresponding Google Drive URL
+if (!$file_key) {
+    // The provided file path was not found in the list. We'll let the client know they fucked up.
+    header('HTTP/1.0 404 not found');
+    die();
+}
+
+// Now on to get the actual image from GDrive:
 $drive_url = "https://drive.google.com/uc?export=view&id={$file_key}"; // URL of file on google drive
 $cache_seconds = intval(htmlentities($_GET["max_age"] ?? $DEFAULT_CACHE_TIME_SECONDS));
 
@@ -14,4 +42,3 @@ fetch_with_cache($drive_url, $file_key, $cache_seconds);
 
 // This ends the currently running process, so we don't keep hogging server resources.
 die();
-?>

--- a/configuration.js
+++ b/configuration.js
@@ -1,21 +1,17 @@
 // This URL refers to a deployment of the AppsScript code which is contained in the TSNCOR spreadsheet.
 // To find that, open the spreadsheet, then go to Extensions --> AppsScript.
 // The code there contains an explanation of how to get/update this URL.
-const TSNCOR_DEPLOYMENT_WEB_APP_URL = "https://script.google.com/macros/s/AKfycbzspyIb_DzhrM8mQPPKrFmnd-BJ3EFMNPzBH6ZoMOAUcXbOWn9WL_88yyl2VISX0J4cHg/exec"
 
 
 // The path suffices for these URLs are also defined in the AppsScript.
-export const TSNCOR_OFFICERS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=officers`
-export const TSNCOR_AWARDS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=awards`
-export const TSNCOR_AWARDS_RECORDS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=awardrecords`
-export const TSNCOR_SHIPS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=ships`
-export const TSNCOR_RANKS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=ranks`
-export const TSNCOR_STARDATES_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=stardates`
-export const TSNCOR_QUALIFICATIONS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=qualifications`
-export const TSNCOR_QUALIFICATIONS_RECORDS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=qualificationrecords`
-export const TSNCOR_ASSIGNMENTS_RECORDS_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?sheet=assignmentrecords`
-export const TSNCOR_IMAGES_URL = `${TSNCOR_DEPLOYMENT_WEB_APP_URL}?images`
+export const TSNCOR_OFFICERS_URL = "api/appsscript.php?key=sheet&val=officers&max_age=3600";
+export const TSNCOR_AWARDS_URL = "api/appsscript.php?key=sheet&val=awards";
+export const TSNCOR_AWARDS_RECORDS_URL = "api/appsscript.php?key=sheet&val=awardrecords";
+export const TSNCOR_SHIPS_URL = "api/appsscript.php?key=sheet&val=ships";
+export const TSNCOR_RANKS_URL = "api/appsscript.php?key=sheet&val=ranks";
+export const TSNCOR_STARDATES_URL = "api/appsscript.php?key=sheet&val=stardates";
 
+export const AWARD_IMAGE_BASE_URL = "api/images.php?key="
 // Time, in milliseconds, for which records that rarely update are cached.
 // These records are basically everything except officers and award records.
 // Users can always force a full refresh via the refresh button on the website.

--- a/modules/api.js
+++ b/modules/api.js
@@ -46,11 +46,6 @@ export async function fetchStardateData() {
     return stardates;
 }
 
-export async function fetchAwardImages() {
-    let awardImages = await fetchWithCache(Config.TSNCOR_IMAGES_URL, Config.LONG_CACHE_DURATION)
-    return awardImages;
-}
-
 export async function resetCache() {
     localStorage.clear();
 }

--- a/modules/store.js
+++ b/modules/store.js
@@ -149,7 +149,7 @@ export const store = reactive({
         if (id === undefined) {
             return Config.RIBBON_MISSING_FILE;
         }
-        return `https://drive.google.com/uc?export=view&id=${id}`
+        return `${Config.AWARD_IMAGE_BASE_URL}${id}`
     },
 
     getOfficerRecordByName(name) {

--- a/modules/store.js
+++ b/modules/store.js
@@ -24,7 +24,6 @@ export const store = reactive({
     ranks: [],
     stardates: [],
     assignmentRecords: [],
-    awardImages: {},
 
     refreshing: false,
 
@@ -102,9 +101,6 @@ export const store = reactive({
     updateStardates(stardates) {
         this.stardates = stardates;
     },
-    updateAwardImages(awardImages) {
-        this.awardImages = awardImages;
-    },
 
     showOfficers() {
         this.displayTab = "officers";
@@ -140,16 +136,7 @@ export const store = reactive({
         if (path === undefined) {
             return Config.RIBBON_MISSING_FILE;
         }
-        if (Object.keys(this.awardImages).length === 0) {
-            // Award images data has not yet been loaded
-            return Config.RIBBON_LOADING_FILE;
-        }
-        let correctedPath = Object.keys(this.awardImages).find(k => k.toLowerCase() === path.toLowerCase())
-        let id = this.awardImages[correctedPath]
-        if (id === undefined) {
-            return Config.RIBBON_MISSING_FILE;
-        }
-        return `${Config.AWARD_IMAGE_BASE_URL}${id}`
+        return `${Config.AWARD_IMAGE_BASE_URL}${encodeURIComponent(path)}`
     },
 
     getOfficerRecordByName(name) {


### PR DESCRIPTION
This has two great effects:

* It fixes the issue with the award images. Google no longer allows hotlinking images from Google Drive (which we've been doing so far). With this change, the images are instead fetched to the TSN server and then linked from there. So this change fixes images 🎉 
* As an added bonus, we now have a server side cache: The site should be a lot faster overall.